### PR TITLE
Table: fix invalid restore of scroll top

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableForm.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableForm.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import {Column, dates, Form, FormModel, GroupBox, HtmlTile, icons, InitModelOf, MessageBoxes, models, numbers, scout, StaticLookupCall, TabItem, TableAppLinkActionEvent, TableRowModel} from '@eclipse-scout/core';
+import {arrays, Column, dates, Form, FormModel, GroupBox, HtmlTile, icons, InitModelOf, MessageBoxes, models, numbers, scout, StaticLookupCall, TabItem, TableAppLinkActionEvent, TableRowModel} from '@eclipse-scout/core';
 import {BooleanColumnPropertiesBox, ColumnLookupCall, DateColumnPropertiesBox, LocaleLookupCall, LookupCallColumnPropertiesBox, LookupColumnPropertiesBox, NumberColumnPropertiesBox, TableFieldTable, TableFormWidgetMap} from '../index';
 import TableFormModel from './TableFormModel';
 
@@ -37,6 +37,7 @@ export class TableForm extends Form {
 
     this.table = this.widget('Table');
     this.widget('AddRowMenu').on('action', this._onAddRowMenuAction.bind(this));
+    this.widget('SelectLastRowMenu').on('action', this._onSelectLastRowAction.bind(this));
     this.widget('MoveToTopMenu').on('action', this._onMoveToTopMenuAction.bind(this));
     this.widget('MoveUpMenu').on('action', this._onMoveUpMenuAction.bind(this));
     this.widget('MoveDownMenu').on('action', this._onMoveDownMenuAction.bind(this));
@@ -191,6 +192,13 @@ export class TableForm extends Form {
 
   protected _onAddRowMenuAction() {
     this.table.insertRow(this._createRow());
+  }
+
+  protected _onSelectLastRowAction() {
+    if (arrays.hasElements(this.table.rows)) {
+      let lastRow = arrays.last(this.table.rows);
+      this.table.selectRow(lastRow);
+    }
   }
 
   protected _onMoveToTopMenuAction() {

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableFormModel.ts
@@ -116,6 +116,11 @@ export default (): FormModel => ({
                   keyStroke: 'insert'
                 },
                 {
+                  id: 'SelectLastRowMenu',
+                  objectType: Menu,
+                  text: '${textKey:SelectLastRow}'
+                },
+                {
                   id: 'MoveMenu',
                   objectType: Menu,
                   text: '${textKey:Move}',
@@ -309,6 +314,7 @@ export class TableFieldTable extends Table {
 export type TableFieldTableWidgetMap = {
   'AggregateTableControl': AggregateTableControl;
   'AddRowMenu': Menu;
+  'SelectLastRowMenu': Menu;
   'MoveMenu': Menu;
   'MoveToTopMenu': Menu;
   'MoveUpMenu': Menu;

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/resources/org/eclipse/scout/jswidgets/ui/html/texts/Texts.properties
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/resources/org/eclipse/scout/jswidgets/ui/html/texts/Texts.properties
@@ -102,6 +102,7 @@ ResetMenuTooltip=Resets the form to its initial state.
 RevealTooltip=Brings the widget into view by scrolling the first scrollable parent. The action does not have any effect if the widget is already fully visible or there is no scrollbar. \r\n\r\nIn order to test it make the window smaller so that the scrollbar appears, then scroll the widget out of view and press the button.
 Salutation=Salutation
 SaveMenuTooltip=Saves the changes without closing the form.
+SelectLastRow=Select last row
 Settings=Settings
 SmartField=Smart Field
 SpellCheckEnabledTooltip=This flag requires the spell checker of the browser to be enabled (check browser settings).\r\n\r\nAlso, depending on your browser, changing the flag dynamically may not have an immediate effect. Try to adjust the text, leave the field (focus out) or rerender the field (navigate to another widget and come back) to force the browser to reapply the setting.

--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/TableFieldForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/TableFieldForm.java
@@ -1257,6 +1257,25 @@ public class TableFieldForm extends AbstractForm implements IPageForm {
               }
             }
 
+            @Order(17)
+            @ClassId("31d37347-2c4a-46f6-bec1-7f9de9b24478")
+            public class SelectLastRowMenu extends AbstractMenu {
+              @Override
+              protected String getConfiguredText() {
+                return TEXTS.get("SelectLastRow");
+              }
+
+              @Override
+              protected void execAction() {
+                selectLastRow();
+              }
+
+              @Override
+              protected Set<? extends IMenuType> getConfiguredMenuTypes() {
+                return CollectionUtility.<IMenuType> hashSet(TableMenuType.EmptySpace);
+              }
+            }
+
             @Order(20)
             @ClassId("09b54c41-321e-404c-aba9-543db48d2fd0")
             public class ToggleGroupingStyle extends AbstractMenu {

--- a/code/widgets/org.eclipse.scout.widgets.shared/src/main/resources/org/eclipse/scout/widgets/shared/texts/Texts.properties
+++ b/code/widgets/org.eclipse.scout.widgets.shared/src/main/resources/org/eclipse/scout/widgets/shared/texts/Texts.properties
@@ -622,6 +622,7 @@ SearchRequired=Search Required
 Section=Section
 Select=Select
 SelectAll=Select all
+SelectLastRow=Select last row
 SelectLocale=Select the locale used for formatting
 SelectNone=Select none
 SelectTab=Select tab


### PR DESCRIPTION
When the table rows are replaced, e.g. during the load of data, the scrollTop gets restored after the tableBuffer completed its work. This is not desired when scrollToSelection is active, because the scroll position depends on the selected row and can change during buffering. Therefore, the restore gets aborted when scrollToSelection is active.

450627