### PR TITLE
Content Security Policy: Set 'object-src' to 'none' by default

### DIFF
--- a/docs/modules/migration/partials/migration-guide-26.2.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.2.adoc
@@ -645,3 +645,11 @@ propertyName === 'value'[\s\S]*?\{[\s\S]*?\bthrow\b[\s\S]*?\}
 These expressions are intended as a best-effort search and may not find every occurrence.
 
 We do not expect many affected cases, as using a `ValueFieldValidator` has always been the recommended approach.
+
+== Content Security Policy
+
+Following the https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/object-src[MDN recommendation], the content security policy directive `object-src` has been changed from `self` to `none` by default.
+
+If still using `object-src`, consider moving to more modern alternatives like `<video>`, `<audio>`, `<img>` for e.g. SVG or `<iframe>` using a sandbox.
+
+If you really need `object-src`, add the corresponding directive to the `scout.cspDirectiveAppend` config property (in your `config.properties` file or the environment variable).

--- a/docs/modules/technical-guide/pages/common-concepts/security.adoc
+++ b/docs/modules/technical-guide/pages/common-concepts/security.adoc
@@ -52,7 +52,6 @@ Scout uses the following CSP settings:
 .. `manifest-src`: `'self'`
 .. `manifest-src`: `'self'`
 .. `media-src`: `'self'`
-.. `object-src`: `'self'`
 .. `worker-src`: `'self'`
 --
 +


### PR DESCRIPTION
Following the MDN recommendation to prevent DOM based XSS object-src is disabled by default.

Additionally it is rarely used today and for most there are modern alternatives: <video>, <audio>, <img>, <iframe>.

476399