### PR TITLE
ChunkedDataWriter: fetch and iterate within the same transaction

### DIFF
--- a/code/org.eclipse.scout.docs.snippets/src/main/java/org/eclipse/scout/docs/snippets/rest/ChunkedResource.java
+++ b/code/org.eclipse.scout.docs.snippets/src/main/java/org/eclipse/scout/docs/snippets/rest/ChunkedResource.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.scout.docs.snippets.rest;
 
 import java.util.Iterator;
@@ -24,8 +33,7 @@ public class ChunkedResource implements IRestResource {
   @Produces(MediaType.APPLICATION_JSON)
   public Response loadData() {
     IChunkedDataWriter<ExampleEntityDo> writer = IChunkedDataWriter.create(ExampleEntityDo.class, "\r\n", 100);
-    Iterator<ExampleEntityDo> iterator = fetchData();
-    return writer.toResponse(iterator);
+    return writer.toResponse(this::fetchData);
   }
 
   /**


### PR DESCRIPTION
Chunked data transfer is used for large amounts of data, such as those loaded from a database. In this case, it is absolutely necessary that the execution of the SQL statement and the iteration over the ResultSet take place within the same transaction.

This change modifies the signature of toResponse from an Iterator<T> to a Supplier<Iterator<T>>, allowing to create and iterate in the same RunContext.

474697